### PR TITLE
Use correct shebang

### DIFF
--- a/variables.pl
+++ b/variables.pl
@@ -1,4 +1,4 @@
-###!/usr/bin/perl.exe
+#!/usr/bin/env perl
 #
 # ppx pf1e perl - PPX PF1e Character Builder 
 # version 0.002a (CORE+) NON-MYTHIC NON-PFS


### PR DESCRIPTION
The original shebang is not correct nor valid, even on WSL. This fixes the shebang and comes with the added bonus GitHub will now correctly detect the file is Perl rather than having to fall through to the heuristics and the classifier where is makes a bad guess based on the content and the samples it has to compare it with.

![CleanShot 2021-05-11 at 09 28 39](https://user-images.githubusercontent.com/627280/117784288-51caec80-b23b-11eb-979d-49d5bf9c943e.png)

This won't affect usage either.